### PR TITLE
turning off rms-supporters.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ SHELL := bash
 all: rms-supporters-haters-highlighter.user.css
 
 rms-supporters:
-	$(PYTHON) rms-supporters.py
+#	$(PYTHON) rms-supporters.py
+	touch rms-supporters.sh
 	$(SHELL)  rms-supporters.sh
 
 rms-haters:
@@ -23,4 +24,4 @@ clean:
 		rms-haters-gh.txt rms-haters-global.txt rms-haters.txt \
 		gigachads-gh.txt gigachads-global.txt \
 		rms-supporters-haters-highlighter.user.css
-	rm -rf rms-support-letter.github.io
+#	rm -rf rms-support-letter.github.io

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: rms-supporters-haters-highlighter.user.css
 
 rms-supporters:
 #	$(PYTHON) rms-supporters.py
-	touch rms-supporters.sh
+	touch rms-supporters.txt
 	$(SHELL)  rms-supporters.sh
 
 rms-haters:
@@ -24,4 +24,5 @@ clean:
 		rms-haters-gh.txt rms-haters-global.txt rms-haters.txt \
 		gigachads-gh.txt gigachads-global.txt \
 		rms-supporters-haters-highlighter.user.css
+# enable for automatic support-letter repository deletion
 #	rm -rf rms-support-letter.github.io


### PR DESCRIPTION
something is off with it, as you said is probably due to similar names
turning it off while we figure it out? it does remove many of the non-frens from the open letter from being classified as based
also, I think there is something wrong with sort-ppl.py too, I suspect many of the gigachads are being wrongly classified